### PR TITLE
Add inline svg helper for rails

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -10,6 +10,8 @@ times a year by multiple people.
 
 ## Areas
 * [CSS](https://github.com/railslove/patterns/tree/master/css)
+* [Ruby on
+  Rails](https://github.com/railslove/patterns/tree/master/ruby_on_rails)
 
 ### Porpose
 

--- a/ruby_on_rails/Readme.md
+++ b/ruby_on_rails/Readme.md
@@ -1,0 +1,3 @@
+# Ruby on Rails
+
+* [Inline SVG helper](https://github.com/railslove/patterns/blob/master/ruby_on_rails/inline_svg_helper.md)

--- a/ruby_on_rails/inline_svg_helper.md
+++ b/ruby_on_rails/inline_svg_helper.md
@@ -1,0 +1,22 @@
+# Inline SVGs
+
+Often times, we need inline svgs in Rails, which is not natively supported.
+There's a rather simple approach to adding this functionality by adding a helper
+to `application_helper.rb` (taken from
+https://cobwwweb.com/render-inline-svg-rails-middleman):
+
+```ruby
+  module ApplicationHelper
+    def svg(name)
+      file_path = "#{Rails.root}/app/assets/images/#{name}.svg"
+      return File.read(file_path).html_safe if File.exists?(file_path)
+      "[svg '#{name}' not found]"
+    end
+  end
+```
+
+In your views, you then can simply call
+
+```haml
+  .aIcon= svg('icon_close')
+```

--- a/ruby_on_rails/inline_svg_helper.md
+++ b/ruby_on_rails/inline_svg_helper.md
@@ -7,7 +7,7 @@ https://cobwwweb.com/render-inline-svg-rails-middleman):
 
 ```ruby
   module ApplicationHelper
-    def svg(name)
+    def inline_svg(name)
       file_path = "#{Rails.root}/app/assets/images/#{name}.svg"
       return File.read(file_path).html_safe if File.exists?(file_path)
       "[svg '#{name}' not found]"
@@ -18,5 +18,5 @@ https://cobwwweb.com/render-inline-svg-rails-middleman):
 In your views, you then can simply call
 
 ```haml
-  .aIcon= svg('icon_close')
+  .aIcon= inline_svg('icon_close')
 ```


### PR DESCRIPTION
_To make the discussion easier, below are the contents of the file added_

------

#### Inline SVGs
Often times, we need inline svgs in Rails, which is not natively supported.
There's a rather simple approach to adding this functionality by adding a helper
to `application_helper.rb` (taken from
https://cobwwweb.com/render-inline-svg-rails-middleman):
```ruby
  module ApplicationHelper
    def svg(name)
      file_path = "#{Rails.root}/app/assets/images/#{name}.svg"
      return File.read(file_path).html_safe if File.exists?(file_path)
      "[svg '#{name}' not found]"
    end
  end
```
In your views, you then can simply call
```haml
  .aIcon= svg('icon_close')
```